### PR TITLE
dev: Separate fts3 server, rest, web to own deployments

### DIFF
--- a/overlays/dev/fts3/etc/docker-entrypoint.sh
+++ b/overlays/dev/fts3/etc/docker-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+# Mounting the secrets that we have as files
+echo ">> Secrets and Configs Manipulation <<"
+cp /opt/fts3/fts3-host-pems/hostcert.pem /etc/grid-security/
+cp /opt/fts3/fts3-host-pems/hostcert.pem /etc/pki/tls/certs/localhost.crt
+chmod 644 /etc/grid-security/hostcert.pem
+chmod 644 /etc/pki/tls/certs/localhost.crt
+chown root:root /etc/grid-security/hostcert.pem
+chown root:root /etc/pki/tls/certs/localhost.crt
+
+cp /opt/fts3/fts3-host-pems/hostkey.pem /etc/grid-security/
+cp /opt/fts3/fts3-host-pems/hostkey.pem /etc/pki/tls/private/localhost.key
+chmod 400 /etc/grid-security/hostkey.pem
+chmod 400 /etc/pki/tls/private/localhost.key
+chown root:root /etc/grid-security/hostkey.pem
+chown root:root /etc/pki/tls/private/localhost.key
+
+# Process configs using envsubst to keep configs public
+envsubst < /opt/fts3/fts3-configs/fts3config > /etc/fts3/fts3config
+#envsubst < /opt/fts3/fts3-configs/fts3restconfig > /etc/fts3/fts3restconfig
+envsubst < /opt/fts3/fts3-configs/fts-activemq.conf > /etc/fts3/fts-activemq.conf
+
+#chown root:apache /etc/fts3web/fts3web.ini
+#chown -R fts3:fts3 /var/log/fts3rest
+chown -R fts3:fts3 /var/log/fts3
+#chown -R fts3:fts3 /var/log/fts3web
+
+
+if [[ ! -z "${DATABASE_UPGRADE}" ]]; then
+   echo ">> Database Upgrade <<"
+   yes Y | python /usr/share/fts/fts-database-upgrade.py
+fi
+
+#echo ">> Set FTS3 Aliases <<"
+#python3 /opt/fts3/cluster-hostname-aliasing.py
+
+# Remove TLSv1.3 support from monitoring server config : See https://its.cern.ch/jira/browse/FTS-2037 for more information
+#sed -i -e 's^SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1^SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1 -TLSv1.3^g' /etc/httpd/conf.d/ftsmon.conf
+
+# Add a ServerName to the HTTPD configuration
+#echo ">> Creating /etc/httpd/conf.d/fqdn.conf <<"
+#echo "ServerName localhost" > /etc/httpd/conf.d/fqdn.conf
+
+#! HERE: Do we need to run again? It fails to execute but this is an init container process already (okd)
+# echo ">> START fetch-crl <<"
+# fetch-crl  
+
+#echo ">> START httpd <<"                                                      
+#httpd
+
+#echo ">> EXEC restart_httpd.sh <<"
+#echo 'while true; do sleep 3600; &>/dev/null httpd -k graceful; done' > /root/restart_httpd.sh
+#chmod +x /root/restart_httpd.sh
+#nohup /root/restart_httpd.sh &
+
+echo ">> START supervisord <<"
+supervisord -c /etc/supervisord.conf --nodaemon

--- a/overlays/dev/fts3/etc/supervisord.conf
+++ b/overlays/dev/fts3/etc/supervisord.conf
@@ -1,0 +1,52 @@
+[supervisord]
+nodaemon=true
+user=root
+startsecs = 0
+
+[supervisorctl]
+# setup XML-RPC, which supervisorctl uses to communicate with the supervisord socket
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[program:fts-qos]
+command=/usr/sbin/fts_qos -n
+autostart=true
+autorestart=true
+priority=50
+stdout_logfile=/var/log/fts-qos-%(host_node_name)s.log
+stdout_logfile_maxbytes=0
+stderr_logfile=/var/log/fts-qos-%(host_node_name)s-error.log
+stderr_logfile_maxbytes=0
+
+[program:fts-server]
+command=/usr/sbin/fts_server -n
+autostart=true
+autorestart=true
+priority=50
+stdout_logfile=/var/log/fts-server-%(host_node_name)s.log
+stdout_logfile_maxbytes=0
+stderr_logfile=/var/log/fts-server-%(host_node_name)s-error.log
+stderr_logfile_maxbytes=0
+
+[program:fts-activemq]
+command=/usr/sbin/fts_activemq -n
+autostart=false
+autorestart=false
+priority=50
+stdout_logfile=/var/log/fts-activemq-%(host_node_name)s.log
+stdout_logfile_maxbytes=0
+stderr_logfile=/var/log/fts-activemq-%(host_node_name)s-error.log
+stderr_logfile_maxbytes=0
+
+[program:fts-optimizer]
+command=/usr/sbin/fts_optimizer -n
+autostart=true
+autorestart=true
+priority=50
+stdout_logfile=/var/log/fts-optimizer-%(host_node_name)s.log
+stdout_logfile_maxbytes=0
+stderr_logfile=/var/log/fts-optimizer-%(host_node_name)s-error.log
+stderr_logfile_maxbytes=0

--- a/overlays/dev/fts3/fts3mon.yaml
+++ b/overlays/dev/fts3/fts3mon.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fts3
+  name: fts3-mon
   labels:
-    app: fts3
+    app: fts3-mon
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: fts3
+      app: fts3-mon
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: fts3
+        app: fts3-mon
     spec:
       volumes:
         - name: fts3-configs
@@ -29,19 +29,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: fts-rest-entrypoint
-          secret:
-            defaultMode: 0750
-            secretName: fts-rest-entrypoint
         - name: grid-certificates
           persistentVolumeClaim:
             claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
-        - name: supervisord-conf
-          configMap:
-            name: supervisord-conf
       restartPolicy: Always
       initContainers:
       - name: fetch-crls-first-time
@@ -51,22 +44,36 @@ spec:
           - name: grid-certificates
             mountPath: /out/
       - name: prep-log-pvc
-        image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.2
+        image: ghcr.io/fnal-fife/fts3-mon:3.14.2
         imagePullPolicy: Always
         command: ["/bin/sh", "-c", "cp -r /var/log/* /out/"]
         volumeMounts:
           - name: fts3-logs
             mountPath: /out/
       containers:
-        - name: fts3-server-logs
+        - name: httpd-error-logs
           image: busybox:latest
           imagePullPolicy: Always
-          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/fts-server-$(hostname).log']
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/httpd/fts3web_error_log']
           volumeMounts:
             - name: fts3-logs
               mountPath: /var/log
-        - name: fts3
-          image: ghcr.io/fnal-fife/fts3-al9:3.14.2
+        - name: httpd-access-logs
+          image: busybox:latest
+          imagePullPolicy: Always
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/httpd/fts3web_access_log']
+          volumeMounts:
+            - name: fts3-logs
+              mountPath: /var/log
+        - name: fts3mon-logs
+          image: busybox:latest
+          imagePullPolicy: Always
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/fts3web/fts3web.log']
+          volumeMounts:
+            - name: fts3-logs
+              mountPath: /var/log
+        - name: fts3-mon
+          image: ghcr.io/fnal-fife/fts3-mon:3.14.2
           imagePullPolicy: Always
           resources:
             limits:
@@ -83,12 +90,9 @@ spec:
               mountPath: /etc/grid-security/certificates
             - name: fts3-logs
               mountPath: /var/log
-            - name: supervisord-conf
-              mountPath: /etc/supervisord.conf
-              subPath: supervisord.conf
-            - name: fts-rest-entrypoint
-              mountPath: /tmp/docker-entrypoint.sh
-              subPath: docker-entrypoint.sh
+          ports:
+            - containerPort: 8449
+              protocol: TCP
           env:
             - name: MARIADB_USER
               valueFrom:
@@ -110,10 +114,8 @@ spec:
                 secretKeyRef:
                   name: fts3-db
                   key: db-name
-            #- name: WEB_INTERFACE
-            #  value: usdf-fts3-dev.slac.stanford.edu
-            #- name: DATABASE_UPGRADE
-            #  value: "yes"
+            - name: WEB_INTERFACE
+              value: usdf-fts3-dev.slac.stanford.edu
           readinessProbe:
             exec:
               command:

--- a/overlays/dev/fts3/fts3rest.yaml
+++ b/overlays/dev/fts3/fts3rest.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fts3
+  name: fts3-rest
   labels:
-    app: fts3
+    app: fts3-rest
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: fts3
+      app: fts3-rest
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: fts3
+        app: fts3-rest
     spec:
       volumes:
         - name: fts3-configs
@@ -29,19 +29,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: fts-rest-entrypoint
-          secret:
-            defaultMode: 0750
-            secretName: fts-rest-entrypoint
         - name: grid-certificates
           persistentVolumeClaim:
             claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
-        - name: supervisord-conf
-          configMap:
-            name: supervisord-conf
       restartPolicy: Always
       initContainers:
       - name: fetch-crls-first-time
@@ -51,22 +44,36 @@ spec:
           - name: grid-certificates
             mountPath: /out/
       - name: prep-log-pvc
-        image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.2
+        image: ghcr.io/fnal-fife/fts3-rest:3.14.2
         imagePullPolicy: Always
         command: ["/bin/sh", "-c", "cp -r /var/log/* /out/"]
         volumeMounts:
           - name: fts3-logs
             mountPath: /out/
       containers:
-        - name: fts3-server-logs
+        - name: httpd-error-logs
           image: busybox:latest
           imagePullPolicy: Always
-          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/fts-server-$(hostname).log']
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/httpd/fts3rest_error_log']
           volumeMounts:
             - name: fts3-logs
               mountPath: /var/log
-        - name: fts3
-          image: ghcr.io/fnal-fife/fts3-al9:3.14.2
+        - name: httpd-access-logs
+          image: busybox:latest
+          imagePullPolicy: Always
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/httpd/fts3rest_access_log']
+          volumeMounts:
+            - name: fts3-logs
+              mountPath: /var/log
+        - name: fts3rest-logs
+          image: busybox:latest
+          imagePullPolicy: Always
+          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/fts3rest/fts3rest.log']
+          volumeMounts:
+            - name: fts3-logs
+              mountPath: /var/log
+        - name: fts3-rest
+          image: ghcr.io/fnal-fife/fts3-rest:3.14.2
           imagePullPolicy: Always
           resources:
             limits:
@@ -83,12 +90,9 @@ spec:
               mountPath: /etc/grid-security/certificates
             - name: fts3-logs
               mountPath: /var/log
-            - name: supervisord-conf
-              mountPath: /etc/supervisord.conf
-              subPath: supervisord.conf
-            - name: fts-rest-entrypoint
-              mountPath: /tmp/docker-entrypoint.sh
-              subPath: docker-entrypoint.sh
+          ports:
+            - containerPort: 8446
+              protocol: TCP
           env:
             - name: MARIADB_USER
               valueFrom:
@@ -110,19 +114,31 @@ spec:
                 secretKeyRef:
                   name: fts3-db
                   key: db-name
-            #- name: WEB_INTERFACE
-            #  value: usdf-fts3-dev.slac.stanford.edu
-            #- name: DATABASE_UPGRADE
-            #  value: "yes"
+            - name: WEB_INTERFACE
+              value: usdf-fts3-dev.slac.stanford.edu
           readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -i
-              - -c
-              - mysql --host=${MARIADB_CONNECTION_STRING} -P 3306 --user=$MARIADB_USER --password="$MARIADB_PASSWORD" --database=fts3db -e 'SELECT 1'
+#            exec:
+#              command:
+#              - /bin/sh
+#              - -i
+#              - -c
+#              - mysql --host=${MARIADB_CONNECTION_STRING} -P 3306 --user=$MARIADB_USER --password="$MARIADB_PASSWORD" --database=fts3db -e 'SELECT 1'
+            httpGet:
+              path: /whoami
+              port: 8446
+              scheme: HTTPS
             failureThreshold: 3
             initialDelaySeconds: 30
             periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /whoami
+              port: 8446
+              scheme: HTTPS
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 60
             successThreshold: 1
             timeoutSeconds: 1

--- a/overlays/dev/fts3/kustomization.yaml
+++ b/overlays/dev/fts3/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - ns.yaml
   - pvcs.yaml
   - deployment.yaml
+  - fts3rest.yaml
+  - fts3mon.yaml
   - service.yaml
   - cronjobs.yaml
 
@@ -27,5 +29,16 @@ secretGenerator:
     files:
     - password=etc/secrets/fts3db-fts3-password
     - username=etc/secrets/fts3db-username
-    - conn-str=etc/secrets/fts3db-connection-string
+#    - conn-str=etc/secrets/fts3db-connection-string
+    - conn-str=etc/secrets/fts3db-connection-string-cluster
     - db-name=etc/secrets/fts3db-name
+  - name: fts-rest-entrypoint
+    options:
+      disableNameSuffixHash: true
+    files:
+    - docker-entrypoint.sh=etc/docker-entrypoint.sh
+
+configMapGenerator:
+  - name: supervisord-conf
+    files:
+    - supervisord.conf=etc/supervisord.conf

--- a/overlays/dev/fts3/pvcs.yaml
+++ b/overlays/dev/fts3/pvcs.yaml
@@ -18,4 +18,4 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi
+      storage: 50Gi

--- a/overlays/dev/fts3/service.yaml
+++ b/overlays/dev/fts3/service.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: fts3
+  name: fts3-rest
   labels:
-    app: fts3
-  namespace: fts3
+    app: fts3-rest
+  namespace: fts3-rest
   annotations:
     metallb.io/address-pool: sdf-dmz
     #metallb.io/ip-allocated-from-pool: sdf-dmz
     metallb.io/loadBalancerIPs: 134.79.23.186
+    metallb.io/allow-shared-ip: 134.79.23.186
 spec:
   type: LoadBalancer
   ports:
@@ -16,10 +17,28 @@ spec:
       targetPort: 8446
       protocol: TCP
       name: fts3-rest
+  selector:
+    app: fts3-rest
+  allocateLoadBalancerNodePorts: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fts3-mon
+  labels:
+    app: fts3-mon
+  namespace: fts3-mon
+  annotations:
+    metallb.io/address-pool: sdf-dmz
+    metallb.io/loadBalancerIPs: 134.79.23.186
+    metallb.io/allow-shared-ip: 134.79.23.186
+spec:
+  type: LoadBalancer
+  ports:
     - port: 8449
       targetPort: 8449
       protocol: TCP
       name: fts3-mon
   selector:
-    app: fts3
+    app: fts3-mon
   allocateLoadBalancerNodePorts: false


### PR DESCRIPTION
Changes dev to use separate fts3 server, rest, and web (mon) deployments and images. A step towards being able to better scale fts3 components and also improve logging.