### PR TITLE
Utilize separate fts server image

### DIFF
--- a/overlays/dev/Makefile
+++ b/overlays/dev/Makefile
@@ -21,7 +21,7 @@ get-secrets:
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-username
 	vault kv get --field=fts3db-fts3-password secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-fts3-password
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-username
-	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-connection-string
+	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-connection-string
 	vault kv get --field=fts3db-name secret/rubin/usdf-fts3-dev/fts3db  > mariadb/etc/secrets/fts3db-name
 
 #cert-manager:

--- a/overlays/dev/fts3/deployment.yaml
+++ b/overlays/dev/fts3/deployment.yaml
@@ -51,22 +51,15 @@ spec:
           - name: grid-certificates
             mountPath: /out/
       - name: prep-log-pvc
-        image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.2
+        image: ghcr.io/fnal-fife/fts3-al9:3.14.2
         imagePullPolicy: Always
         command: ["/bin/sh", "-c", "cp -r /var/log/* /out/"]
         volumeMounts:
           - name: fts3-logs
             mountPath: /out/
       containers:
-        - name: fts3-server-logs
-          image: busybox:latest
-          imagePullPolicy: Always
-          args: [/bin/sh, -c, 'tail -n+1 -F /var/log/fts-server-$(hostname).log']
-          volumeMounts:
-            - name: fts3-logs
-              mountPath: /var/log
         - name: fts3
-          image: ghcr.io/fnal-fife/fts3-al9:3.14.2
+          image: ghcr.io/fnal-fife/fts3-server:3.14.2-s6
           imagePullPolicy: Always
           resources:
             limits:

--- a/overlays/dev/fts3/etc/util.py
+++ b/overlays/dev/fts3/etc/util.py
@@ -1,0 +1,98 @@
+# Copyright notice:
+#
+# Copyright (C) CERN 2013-2015
+#
+# Copyright (C) Members of the EMI Collaboration, 2010-2013.
+#   See www.eu-emi.eu for details on the copyright holders
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
+import os
+import sys
+import settings
+import urllib.parse as urlparse
+
+ACTIVE_STATES        = ['SUBMITTED', 'READY', 'ACTIVE', 'STAGING', 'ARCHIVING']
+FILE_TERMINAL_STATES = ['FINISHED', 'FAILED', 'CANCELED', 'NOT_USED']
+ON_HOLD_STATES       = ['ON_HOLD', 'ON_HOLD_STAGING']
+STATES = ACTIVE_STATES + FILE_TERMINAL_STATES + ON_HOLD_STATES
+
+def get_order_by(request):
+    order_by = request.GET.get('orderby', None)
+    order_desc = False
+
+    if not order_by:
+        order_desc = True
+    elif order_by[0] == '-':
+        order_desc = True
+        order_by = order_by[1:]
+
+    return order_by, order_desc
+
+
+def ordered_field(field, desc):
+    if desc:
+        return '-' + field
+    return field
+
+
+def get_page(paginator, request):
+    try:
+        if 'page' in request.GET:
+            page = paginator.page(request.GET.get('page'))
+        else:
+            page = paginator.page(1)
+    except PageNotAnInteger:
+        page = paginator.page(1)
+    except EmptyPage:
+        page = paginator.page(paginator.num_pages)
+    return page
+
+
+def paged(elements, http_request):
+    try:
+        page_size = int(http_request.GET['page_size'])
+    except:
+        page_size = 50
+    if http_request.GET.get('page', 0) == 'all':
+        page_size = sys.maxsize
+
+    paginator = Paginator(elements, page_size)
+    page = get_page(paginator, http_request)
+
+    return {
+        'count':      paginator.count,
+        'endIndex':   page.end_index(),
+        'startIndex': page.start_index(),
+        'page':       page.number,
+        'pageCount':  paginator.num_pages,
+        'pageSize':   page_size,
+        'items':      page.object_list
+    }
+
+
+def db_limit(sql, limit):
+    if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.oracle':
+        return "SELECT * FROM (%s) WHERE rownum <= %d" % (sql, limit)
+    elif settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
+        return sql + " LIMIT %d" % limit
+    else:
+        return sql
+
+
+def log_link(host, log):
+    if host in settings.HOST_ALIASES:
+        host = settings.HOST_ALIASES[host]
+    host = os.environ.get('WEB_INTERFACE', host)
+    return urlparse.urljoin(settings.LOG_BASE_URL % ({'host': host}), log)

--- a/overlays/dev/fts3/fts3mon.yaml
+++ b/overlays/dev/fts3/fts3mon.yaml
@@ -35,6 +35,9 @@ spec:
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
+        - name: fts3web-libs-util
+          configMap:
+            name: fts3web-libs-util
       restartPolicy: Always
       initContainers:
       - name: fetch-crls-first-time
@@ -90,6 +93,9 @@ spec:
               mountPath: /etc/grid-security/certificates
             - name: fts3-logs
               mountPath: /var/log
+            - name: fts3web-libs-util
+              mountPath: /usr/share/fts3web/libs/util.py
+              subPath: util.py
           ports:
             - containerPort: 8449
               protocol: TCP

--- a/overlays/dev/fts3/kustomization.yaml
+++ b/overlays/dev/fts3/kustomization.yaml
@@ -42,3 +42,6 @@ configMapGenerator:
   - name: supervisord-conf
     files:
     - supervisord.conf=etc/supervisord.conf
+  - name: fts3web-libs-util
+    files:
+    - util.py=etc/util.py

--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -1,5 +1,5 @@
 
 bases:
-- mariadb-operator/
-- mariadb/
+#- mariadb-operator/
+#- mariadb/
 - fts3/


### PR DESCRIPTION
Utilize separate fts server image based on s6.

Includes a patch to fts-monitor's util.py to use the WEB_INTERFACE environment variable to resolve FTS transfer log file path correctly.