### PR TITLE
Update to fts-3.14.4, remove MaxUrlCopyProcess limit, switch to single instance MariaDB

### DIFF
--- a/overlays/prod/Makefile
+++ b/overlays/prod/Makefile
@@ -12,6 +12,7 @@ get-secrets:
 	vault kv get --field=fts3db-fts3-password secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-fts3-password
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-username
 	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
+#	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
 	vault kv get --field=fts3db-name secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-name
 	mkdir -p mariadb/etc/secrets
 	vault kv get --field=fts3db-root-password secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-root-password
@@ -20,6 +21,7 @@ get-secrets:
 	vault kv get --field=fts3db-fts3-password secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-fts3-password
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-username
 	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
+#	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
 	vault kv get --field=fts3db-name secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-name
 
 #cert-manager:

--- a/overlays/prod/Makefile
+++ b/overlays/prod/Makefile
@@ -11,8 +11,8 @@ get-secrets:
 	vault kv get --field=hostkey.pem secret/rubin/usdf-fts3/fts3  > fts3/etc/secrets/hostkey.pem
 	vault kv get --field=fts3db-fts3-password secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-fts3-password
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-username
-	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
-#	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
+#	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
+	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-connection-string
 	vault kv get --field=fts3db-name secret/rubin/usdf-fts3/fts3db  > fts3/etc/secrets/fts3db-name
 	mkdir -p mariadb/etc/secrets
 	vault kv get --field=fts3db-root-password secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-root-password
@@ -20,8 +20,8 @@ get-secrets:
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-username
 	vault kv get --field=fts3db-fts3-password secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-fts3-password
 	vault kv get --field=fts3db-username secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-username
-	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
-#	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
+#	vault kv get --field=fts3db-connection-string secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
+	vault kv get --field=fts3db-connection-string-solo secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-connection-string
 	vault kv get --field=fts3db-name secret/rubin/usdf-fts3/fts3db  > mariadb/etc/secrets/fts3db-name
 
 #cert-manager:

--- a/overlays/prod/fts3/deployment.yaml
+++ b/overlays/prod/fts3/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           - name: grid-certificates
             mountPath: /out/
       - name: prep-log-pvc
-        image: ghcr.io/fnal-fife/fts3-al9:3.14.2-slac
+        image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.4
         imagePullPolicy: Always
         command: ["/bin/sh", "-c", "cp -r /var/log/* /out/"]
         volumeMounts:
@@ -58,7 +58,7 @@ spec:
             mountPath: /out/
       containers:
         - name: fts3
-          image: ghcr.io/fnal-fife/fts3-al9:3.14.2-slac
+          image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.4
           imagePullPolicy: Always
           resources:
             limits:

--- a/overlays/prod/fts3/etc/fts3config
+++ b/overlays/prod/fts3/etc/fts3config
@@ -63,7 +63,7 @@ MyOSG=false
 MaxNumberOfProcesses=25000
 
 #Maximum number of fts_url_copy processes to run on the host. This can be used to protect against resource exhaustion.
-MaxUrlCopyProcesses=30
+###MaxUrlCopyProcesses=30
 
 # Check for fts_url_copy processes that do not give their progress back
 CheckStalledTransfers = false

--- a/overlays/prod/mariadb/backup-solo.yaml
+++ b/overlays/prod/mariadb/backup-solo.yaml
@@ -1,0 +1,19 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Backup
+metadata:
+  name: fts3-db-cluster-solo-backup
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster-solo
+  args:
+    - --verbose
+  storage:
+    persistentVolumeClaim:
+      resources:
+        requests:
+          storage: 40Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: wekafs--sdf-k8s01
+

--- a/overlays/prod/mariadb/backup.yaml
+++ b/overlays/prod/mariadb/backup.yaml
@@ -1,0 +1,21 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Backup
+metadata:
+  name: fts3-db-cluster-2-backup
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster
+  databases:
+    - fts3db
+  args:
+    - --verbose
+  storage:
+    persistentVolumeClaim:
+      resources:
+        requests:
+          storage: 40Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: wekafs--sdf-k8s01
+

--- a/overlays/prod/mariadb/fts3-grants.yaml
+++ b/overlays/prod/mariadb/fts3-grants.yaml
@@ -1,0 +1,37 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: all-grant
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster
+  privileges:
+    - "ALL PRIVILEGES"
+  database: "fts3db"
+  table: "*"
+  username: fts3
+  grantOption: true
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: super-grant
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster
+  privileges:
+    - "SUPER"
+  database: "*"
+  table: "*"
+  username: fts3
+  grantOption: true
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/overlays/prod/mariadb/fts3-solo-grants.yaml
+++ b/overlays/prod/mariadb/fts3-solo-grants.yaml
@@ -1,0 +1,37 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: all-grant-solo
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster-solo
+  privileges:
+    - "ALL PRIVILEGES"
+  database: "fts3db"
+  table: "*"
+  username: fts3
+  grantOption: true
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: super-grant-solo
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster-solo
+  privileges:
+    - "SUPER"
+  database: "*"
+  table: "*"
+  username: fts3
+  grantOption: true
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/overlays/prod/mariadb/fts3-solo-users.yaml
+++ b/overlays/prod/mariadb/fts3-solo-users.yaml
@@ -1,0 +1,18 @@
+# Define the 'fts3' user in the database, and create the grants needed for the FTS3 service.
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: fts3-solo
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster-solo
+  passwordSecretKeyRef:
+    name: fts3-db
+    key: password
+  name: fts3
+  maxUserConnections: 0
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/overlays/prod/mariadb/fts3-users.yaml
+++ b/overlays/prod/mariadb/fts3-users.yaml
@@ -1,0 +1,18 @@
+# Define the 'fts3' user in the database, and create the grants needed for the FTS3 service.
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: fts3
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster
+  passwordSecretKeyRef:
+    name: fts3-db
+    key: password
+  name: fts3
+  maxUserConnections: 0
+  host: "%"
+  cleanupPolicy: Delete
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/overlays/prod/mariadb/kustomization.yaml
+++ b/overlays/prod/mariadb/kustomization.yaml
@@ -2,8 +2,13 @@ namespace: fts3-db
 
 resources:
   - ns.yaml
-  - mariadb-cluster.yaml
-  - fts3.yaml
+  #- mariadb-cluster.yaml
+  #- fts3.yaml
+  #- fts3-users.yaml
+  #- fts3-grants.yaml
+  - mariadb-cluster-solo.yaml
+  - fts3-solo-users.yaml
+  - fts3-solo-grants.yaml
 
 secretGenerator:
   - name: mariadb-root

--- a/overlays/prod/mariadb/mariadb-cluster-solo.yaml
+++ b/overlays/prod/mariadb/mariadb-cluster-solo.yaml
@@ -1,0 +1,94 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: fts3-db-cluster-solo
+  namespace: fts3-db
+spec:
+  rootPasswordSecretKeyRef:
+    name: mariadb-root
+    key: password
+
+  database: fts3db
+  passwordSecretKeyRef:
+    name: mariadb-user
+    key: password
+
+  port: 3306
+
+  image: docker-registry1.mariadb.com/library/mariadb:11.4.3
+
+  imagePullPolicy: IfNotPresent
+
+  myCnf: |
+    [mariadb]
+    bind-address=*
+    default_storage_engine=InnoDB
+    binlog_format=row
+    innodb_autoinc_lock_mode=2
+    max_allowed_packet=256M
+
+    [mysqld]
+    max_user_connections=0
+
+  resources:
+    requests:
+      cpu: 1
+      memory: 4Gi
+    limits:
+      cpu: 4
+      memory: 8Gi
+
+  livenessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+
+  replication:
+    enabled: false
+  #  primary:
+  #    podIndex: 0
+  #    automaticFailover: true
+  #  replica:
+  #    waitPoint: AfterSync
+  #    gtid: CurrentPos
+  #    replPasswordSecretKeyRef:
+  #      name: mariadb-user
+  #      key: password
+  #    connectionTimeout: 10s
+  #    connectionRetries: 10
+  #    syncTimeout: 10s
+  #  syncBinlog: true
+  #  probesEnabled: true
+  #replicas: 3
+
+  storage:
+    size: 200Gi
+    resizeInUseVolumes: true
+    waitForVolumeResize: true
+    storageClassName: wekafs--sdf-k8s01
+    volumeClaimTemplate:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+      storageClassName: wekafs--sdf-k8s01
+
+  #env:
+  #  - name: TZ
+  #    value: SYSTEM
+
+  #envFrom:
+  #  - configMapRef:
+  #      name: mariadb
+
+  #podSecurityContext:
+  #  runAsUser: 0
+
+  #securityContext:
+  #  allowPrivilegeEscalation: false

--- a/overlays/prod/mariadb/pvc-helper-pod.yaml
+++ b/overlays/prod/mariadb/pvc-helper-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-helper
+  namespace: fts3-db
+spec:
+  containers:
+  - name: helper
+    image: alpine
+    command: ["sh", "-c", "while true; do sleep 30; done"]
+    volumeMounts:
+    - name: my-storage
+      mountPath: /mnt/pvc
+  volumes:
+  - name: my-storage
+    persistentVolumeClaim:
+      claimName: fts3-db-cluster-solo-backup

--- a/overlays/prod/mariadb/restore.yaml
+++ b/overlays/prod/mariadb/restore.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Restore
+metadata:
+  name: restore-from-pvc
+  namespace: fts3-db
+spec:
+  mariaDbRef:
+    name: fts3-db-cluster-solo
+  volume:
+    persistentVolumeClaim:
+      claimName: fts3-db-cluster-solo-backup
+  database: fts3db
+  args:
+    - --verbose
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 300m
+      memory: 512Mi
+  affinity:
+    antiAffinityEnabled: true

--- a/scripts/mariadb-dump-command.sh
+++ b/scripts/mariadb-dump-command.sh
@@ -3,9 +3,6 @@
 # Excluded tables are based off of dev recommendations here: https://fts3-docs.web.cern.ch/fts3-docs/docs/install/backup_policy.html#if-backups-are-disabled
 
 mariadb-dump -u root -p$MARIADB_ROOT_PASSWORD fts3db \
-  --tables t_server_config t_optimizer t_optimizer_evolution t_config_audit t_se \
-  t_link_config t_share_config t_activity_share_config t_bad_ses t_bad_dns t_authz_dn t_cloudStorage \
-  t_cloudStorageUser t_oauth2_apps t_oauth2_codes t_oauth2_providers t_oauth2_tokens \
   --ignore-table-data=fts3db.t_job \
   --ignore-table-data=fts3db.t_job_backup \
   --ignore-table-data=fts3db.t_file \
@@ -21,4 +18,51 @@ mariadb-dump -u root -p$MARIADB_ROOT_PASSWORD fts3db \
   --ignore-table-data=fts3db.t_token_provider \
   --ignore-table-data=fts3db.t_webmon_overview_cache \
   --ignore-table-data=fts3db.t_webmon_overview_cache_control \
-  > /tmp/backup.$(date -u +"%Y-%m-%dT%H:%M:%SZ").sql
+  --tables t_server_config t_optimizer t_optimizer_evolution t_config_audit t_se \
+  t_link_config t_share_config t_activity_share_config t_bad_ses t_bad_dns t_authz_dn t_cloudStorage \
+  t_cloudStorageUser t_oauth2_apps t_oauth2_codes t_oauth2_providers t_oauth2_tokens \
+  t_job \
+  t_job_backup \
+  t_file \
+  t_file_backup \
+  t_file_retry_errors \
+  t_dm \
+  t_dm_backup \
+  t_gridmap \
+  t_hosts \
+  t_schema_vers \
+  t_stage_req \
+  t_token \
+  t_token_provider \
+  t_webmon_overview_cache \
+  t_webmon_overview_cache_control \
+  > /tmp/backup.$(date -u +"%Y-%m-%dT%H%M%SZ").sql
+
+
+# only schema
+mariadb-dump -u root -p$MARIADB_ROOT_PASSWORD fts3db \
+  --no-data \
+  > /tmp/backup.$(date -u +"%Y-%m-%dT%H%M%SZ").schema.sql
+
+# selected table data
+mariadb-dump -u root -p$MARIADB_ROOT_PASSWORD fts3db \
+  --no-create-info \
+  --ignore-table-data=fts3db.t_job \
+  --ignore-table-data=fts3db.t_job_backup \
+  --ignore-table-data=fts3db.t_file \
+  --ignore-table-data=fts3db.t_file_backup \
+  --ignore-table-data=fts3db.t_file_retry_errors \
+  --ignore-table-data=fts3db.t_dm \
+  --ignore-table-data=fts3db.t_dm_backup \
+  --ignore-table-data=fts3db.t_gridmap \
+  --ignore-table-data=fts3db.t_hosts \
+  --ignore-table-data=fts3db.t_stage_req \
+  --ignore-table-data=fts3db.t_token \
+  --ignore-table-data=fts3db.t_token_provider \
+  --ignore-table-data=fts3db.t_webmon_overview_cache \
+  --ignore-table-data=fts3db.t_webmon_overview_cache_control \
+  --tables t_server_config t_optimizer t_optimizer_evolution t_config_audit t_se \
+  t_link_config t_share_config t_activity_share_config t_bad_ses t_bad_dns t_authz_dn t_cloudStorage \
+  t_cloudStorageUser t_oauth2_apps t_oauth2_codes t_oauth2_providers t_oauth2_tokens \
+  t_schema_vers \
+  > /tmp/backup.$(date -u +"%Y-%m-%dT%H%M%SZ").data.sql


### PR DESCRIPTION
## Changelog
* Upgrade to use ghcr.io/fnal-fife/fts3-al9/fts-3.14.4 image

* Removed the MaxUrlCopyProcess limit so it now defaults to 400 connections

* Migrate to single instance MariaDB.
  * The previous, three replica deployment had hard to fix reconciliation issues, so it was determined to move to a single replica deployment.
  * Includes scripts, Backup, Restore, and helper pod manifests to do the migration manually.
  * Database connection string vault kv was switched to the solo instance string.