### PR TITLE
dev: Switch to use locally mounted grid certs

### DIFF
--- a/overlays/dev/fts3/deployment.yaml
+++ b/overlays/dev/fts3/deployment.yaml
@@ -29,13 +29,9 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: fts-rest-entrypoint
-          secret:
-            defaultMode: 0750
-            secretName: fts-rest-entrypoint
-        - name: grid-certificates
+        - name: sdf-group-rubin
           persistentVolumeClaim:
-            claimName: grid-certificates-pvc
+            claimName: sdf-group-rubin
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
@@ -44,12 +40,6 @@ spec:
             name: supervisord-conf
       restartPolicy: Always
       initContainers:
-      - name: fetch-crls-first-time
-        image: ghcr.io/fnal-fife/fetch-crl-cron:latest
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: grid-certificates
-            mountPath: /out/
       - name: prep-log-pvc
         image: ghcr.io/fnal-fife/fts3-al9:3.14.2
         imagePullPolicy: Always
@@ -75,16 +65,15 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: grid-certificates
+            - name: sdf-group-rubin
               mountPath: /etc/grid-security/certificates
+              subPath: services/ddm/etc/grid-security/certificates
+              readOnly: true
             - name: fts3-logs
               mountPath: /var/log
             - name: supervisord-conf
               mountPath: /etc/supervisord.conf
               subPath: supervisord.conf
-            - name: fts-rest-entrypoint
-              mountPath: /tmp/docker-entrypoint.sh
-              subPath: docker-entrypoint.sh
           env:
             - name: MARIADB_USER
               valueFrom:

--- a/overlays/dev/fts3/etc/fts3config
+++ b/overlays/dev/fts3/etc/fts3config
@@ -25,7 +25,7 @@ Alias=usdf-fts3-dev.slac.stanford.edu
 SiteName=USDF Development
 
 # Enable or disable monitoring messages (see fts-activemq.conf)
-MonitoringMessaging=true
+MonitoringMessaging=false
 
 # Directory where the internal FTS3 messages are written
 #MessagingDirectory=/var/lib/fts3

--- a/overlays/dev/fts3/fts3mon.yaml
+++ b/overlays/dev/fts3/fts3mon.yaml
@@ -29,23 +29,17 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: grid-certificates
-          persistentVolumeClaim:
-            claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
         - name: fts3web-libs-util
           configMap:
             name: fts3web-libs-util
+        - name: sdf-group-rubin
+          persistentVolumeClaim:
+            claimName: sdf-group-rubin
       restartPolicy: Always
       initContainers:
-      - name: fetch-crls-first-time
-        image: ghcr.io/fnal-fife/fetch-crl-cron:latest
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: grid-certificates
-            mountPath: /out/
       - name: prep-log-pvc
         image: ghcr.io/fnal-fife/fts3-mon:3.14.2
         imagePullPolicy: Always
@@ -89,8 +83,10 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: grid-certificates
+            - name: sdf-group-rubin
               mountPath: /etc/grid-security/certificates
+              subPath: services/ddm/etc/grid-security/certificates
+              readOnly: true
             - name: fts3-logs
               mountPath: /var/log
             - name: fts3web-libs-util

--- a/overlays/dev/fts3/fts3rest.yaml
+++ b/overlays/dev/fts3/fts3rest.yaml
@@ -29,20 +29,14 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: grid-certificates
-          persistentVolumeClaim:
-            claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
+        - name: sdf-group-rubin
+          persistentVolumeClaim:
+            claimName: sdf-group-rubin
       restartPolicy: Always
       initContainers:
-      - name: fetch-crls-first-time
-        image: ghcr.io/fnal-fife/fetch-crl-cron:latest
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: grid-certificates
-            mountPath: /out/
       - name: prep-log-pvc
         image: ghcr.io/fnal-fife/fts3-rest:3.14.2
         imagePullPolicy: Always
@@ -86,8 +80,10 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: grid-certificates
+            - name: sdf-group-rubin
               mountPath: /etc/grid-security/certificates
+              subPath: services/ddm/etc/grid-security/certificates
+              readOnly: true
             - name: fts3-logs
               mountPath: /var/log
           ports:

--- a/overlays/dev/fts3/pvcs.yaml
+++ b/overlays/dev/fts3/pvcs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grid-certificates-pvc
 spec:
   accessModes:
-  - ReadWriteMany
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi
@@ -18,4 +18,16 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 50Gi
+      storage: 250Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sdf-group-rubin
+spec:
+  storageClassName: sdf-group-rubin
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Removed the fetch-crl initContainers in order to use the node grid certificates directory in the sdf-group-rubin.

This change helps cut down the time needed to fetch certificates and crls.