### PR TITLE
dev: Increased AutoSessionReuseMaxSmallFileSize to 300MB

### DIFF
--- a/overlays/dev/fts3/etc/fts3restconfig
+++ b/overlays/dev/fts3/etc/fts3restconfig
@@ -50,7 +50,7 @@ AutoSessionReuse = true
 # Max number of files per session reuse
 AutoSessionReuseMaxFiles = 1000
 # Max small file size for session reuse in bytes (default 100MB)
-AutoSessionReuseMaxSmallFileSize = 104857600
+AutoSessionReuseMaxSmallFileSize = 314572800
 # Max big file size for session reuse in bytes (default 1GB)
 AutoSessionReuseMaxBigFileSize = 1073741824
 # Max number of big files per session reuse


### PR DESCRIPTION
Increased AutoSessionReuseMaxSmallFileSize from 100MB to 300MB in fts3restconfig