### PR TITLE
Revert to fetch-crl for grid-certificates, but use PVC

### DIFF
--- a/overlays/dev/fts3/deployment.yaml
+++ b/overlays/dev/fts3/deployment.yaml
@@ -29,9 +29,9 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
-        - name: sdf-group-rubin
+        - name: grid-certificates
           persistentVolumeClaim:
-            claimName: sdf-group-rubin
+            claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
@@ -65,9 +65,8 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: sdf-group-rubin
+            - name: grid-certificates
               mountPath: /etc/grid-security/certificates
-              subPath: services/ddm/etc/grid-security/certificates
               readOnly: true
             - name: fts3-logs
               mountPath: /var/log

--- a/overlays/dev/fts3/fts3mon.yaml
+++ b/overlays/dev/fts3/fts3mon.yaml
@@ -29,15 +29,15 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
+        - name: grid-certificates
+          persistentVolumeClaim:
+            claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
         - name: fts3web-libs-util
           configMap:
             name: fts3web-libs-util
-        - name: sdf-group-rubin
-          persistentVolumeClaim:
-            claimName: sdf-group-rubin
       restartPolicy: Always
       initContainers:
       - name: prep-log-pvc
@@ -83,9 +83,8 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: sdf-group-rubin
+            - name: grid-certificates
               mountPath: /etc/grid-security/certificates
-              subPath: services/ddm/etc/grid-security/certificates
               readOnly: true
             - name: fts3-logs
               mountPath: /var/log

--- a/overlays/dev/fts3/fts3rest.yaml
+++ b/overlays/dev/fts3/fts3rest.yaml
@@ -29,12 +29,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: fts3-host-pems
+        - name: grid-certificates
+          persistentVolumeClaim:
+            claimName: grid-certificates-pvc
         - name: fts3-logs
           persistentVolumeClaim:
             claimName: fts3-logs-pvc
-        - name: sdf-group-rubin
-          persistentVolumeClaim:
-            claimName: sdf-group-rubin
       restartPolicy: Always
       initContainers:
       - name: prep-log-pvc
@@ -80,9 +80,8 @@ spec:
             - name: fts3-host-pems
               mountPath: /opt/fts3/fts3-host-pems
               readOnly: true
-            - name: sdf-group-rubin
+            - name: grid-certificates
               mountPath: /etc/grid-security/certificates
-              subPath: services/ddm/etc/grid-security/certificates
               readOnly: true
             - name: fts3-logs
               mountPath: /var/log

--- a/overlays/dev/fts3/grid-certificates-job.yaml
+++ b/overlays/dev/fts3/grid-certificates-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fetch-crl-on-install
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: hook-succeeded
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      containers:
+        - args:
+          name: fetch-crl
+          image: ghcr.io/fnal-fife/fetch-crl-cron:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: ca-volume
+              mountPath: /out/
+          resources:
+            requests:
+              cpu: 256m
+              memory: 500M
+            limits:
+              cpu: 256m
+              memory: 500M
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ca-volume
+          persistentVolumeClaim:
+            claimName: grid-certificates-pvc

--- a/overlays/dev/fts3/kustomization.yaml
+++ b/overlays/dev/fts3/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - fts3mon.yaml
   - service.yaml
   - cronjobs.yaml
+  - grid-certificates-job.yaml
   - cleaner-cronjob.yaml
 
 secretGenerator:

--- a/overlays/prod/fts3/deployment.yaml
+++ b/overlays/prod/fts3/deployment.yaml
@@ -43,12 +43,6 @@ spec:
             name: supervisord-conf
       restartPolicy: Always
       initContainers:
-      - name: fetch-crls-first-time
-        image: ghcr.io/fnal-fife/fetch-crl-cron:latest
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: grid-certificates
-            mountPath: /out/
       - name: prep-log-pvc
         image: ghcr.io/fnal-fife/fts3-al9:fts-3.14.4
         imagePullPolicy: Always
@@ -76,6 +70,7 @@ spec:
               readOnly: true
             - name: grid-certificates
               mountPath: /etc/grid-security/certificates
+              readOnly: true
             - name: fts3-logs
               mountPath: /var/log
             - name: supervisord-conf

--- a/overlays/prod/fts3/grid-certificates-job.yaml
+++ b/overlays/prod/fts3/grid-certificates-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fetch-crl-on-install
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: hook-succeeded
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      containers:
+        - args:
+          name: fetch-crl
+          image: ghcr.io/fnal-fife/fetch-crl-cron:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: ca-volume
+              mountPath: /out/
+          resources:
+            requests:
+              cpu: 256m
+              memory: 500M
+            limits:
+              cpu: 256m
+              memory: 500M
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ca-volume
+          persistentVolumeClaim:
+            claimName: grid-certificates-pvc

--- a/overlays/prod/fts3/kustomization.yaml
+++ b/overlays/prod/fts3/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - cronjobs.yaml
+  - grid-certificates-job.yaml
 
 secretGenerator:
   - name: fts3-configs


### PR DESCRIPTION
This reverts using a storageClass for a local mounted grid-certificates. There were some issues with expired intermediary certificates from the storageClass. This PR is an attempt to fix that.

Another change is that instead of using an initContainer for each service, a Job is created to fetch the certificates and crl. The CronJob is still used to update certificates and crls. By not using initContainer, each service pod can be restarted in a timely manner.