### PR TITLE
increase  innodb_buffer_pool_size to 4G 

### DIFF
--- a/overlays/dev/mariadb/mariadb-cluster-solo.yaml
+++ b/overlays/dev/mariadb/mariadb-cluster-solo.yaml
@@ -29,6 +29,7 @@ spec:
 
     [mysqld]
     max_user_connections=0
+    innodb_buffer_pool_size=4G
 
   resources:
     requests:

--- a/overlays/prod/mariadb/mariadb-cluster-solo.yaml
+++ b/overlays/prod/mariadb/mariadb-cluster-solo.yaml
@@ -29,6 +29,7 @@ spec:
 
     [mysqld]
     max_user_connections=0
+    innodb_buffer_pool_size=4G
 
   resources:
     requests:


### PR DESCRIPTION
increase  innodb_buffer_pool_size to 4G from the default 128MB so wecan run large data queries.